### PR TITLE
fix #11 Remove Proxy parameters on rgma.conf

### DIFF
--- a/templates/httpd/rgma.conf.j2
+++ b/templates/httpd/rgma.conf.j2
@@ -20,8 +20,6 @@ Alias /rgma "{{ rgm_root_path }}/rgma/html"
         AuthrgmSessionCookies On
         Require host localhost 127.0.0.1
         Require valid-user
-        ProxyPass http://127.0.0.1:5601/kibana retry=0
-        ProxyPassReverse http://127.0.0.1:5601/kibana/(.*)
 
         Options +Indexes
         Require valid-user


### PR DESCRIPTION
Proxy parameters variable block the launch of apache at the end of setup!