### PR TITLE
Fix MetricBeat Windows Installation on Powershell <5.1

### DIFF
--- a/templates/distrib/markdown/windows_metricbeat_instructions.md
+++ b/templates/distrib/markdown/windows_metricbeat_instructions.md
@@ -7,6 +7,7 @@ From Windows *Start* menu, search for *Windows PowerShell* application, then rig
 Copy/paste the following line into the PowerShell. Don't forget to adapt _-username_ and _-password_ fields to your needs:
 
 ```
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 & $([Scriptblock]::Create((New-Object System.Net.WebClient).DownloadString("https://{{ ansible_default_ipv4.address }}/distrib/install/Add-RGMHost.ps1"))) -username admin -password ******
 ```
 


### PR DESCRIPTION
Change log message on the screen to adapte commandlet with the current version of Powershell
Add more Verbose Messages
Complete Verbose message with more variable content

The error with document and settings whas due to the non existance of the commande let Write-infromation
The try catch whas in double error. first time in try part: write-information cause the error
the second time in the catch part, the writ-information also create an error then the exit in the catch failed!!
