### PR TITLE
fix number of ES index replicas to 0 for Beats

### DIFF
--- a/templates/distrib/conf/linux_metricbeat.yml.j2
+++ b/templates/distrib/conf/linux_metricbeat.yml.j2
@@ -10,6 +10,7 @@ metricbeat.config.modules:
 # Elasticsearch template setting
 setup.template.settings:
   index.number_of_shards: 1
+  index.number_of_replicas: 0
   index.codec: best_compression
 
 # General

--- a/templates/distrib/conf/windows_auditbeat.yml.j2
+++ b/templates/distrib/conf/windows_auditbeat.yml.j2
@@ -15,6 +15,7 @@ auditbeat.modules:
 # Elasticsearch template setting
 setup.template.settings:
   index.number_of_shards: 1
+  index.number_of_replicas: 0
   index.codec: best_compression
 
 

--- a/templates/distrib/conf/windows_filebeat.yml.j2
+++ b/templates/distrib/conf/windows_filebeat.yml.j2
@@ -17,6 +17,7 @@ filebeat.config.modules:
 # Elasticsearch template setting
 setup.template.settings:
   index.number_of_shards: 1
+  index.number_of_replicas: 0
   index.codec: best_compression
 
 

--- a/templates/distrib/conf/windows_heartbeat.yml.j2
+++ b/templates/distrib/conf/windows_heartbeat.yml.j2
@@ -23,6 +23,7 @@ heartbeat.monitors:
 # Elasticsearch template setting
 setup.template.settings:
   index.number_of_shards: 1
+  index.number_of_replicas: 0
   index.codec: best_compression
 
 

--- a/templates/distrib/conf/windows_metricbeat.yml.j2
+++ b/templates/distrib/conf/windows_metricbeat.yml.j2
@@ -9,6 +9,7 @@ metricbeat.config.modules:
 # Elasticsearch template setting
 setup.template.settings:
   index.number_of_shards: 1
+  index.number_of_replicas: 0
   index.codec: best_compression
 
 # General

--- a/templates/distrib/conf/windows_winlogbeat.yml.j2
+++ b/templates/distrib/conf/windows_winlogbeat.yml.j2
@@ -13,6 +13,7 @@ winlogbeat.event_logs:
 # Elasticsearch template setting
 setup.template.settings:
   index.number_of_shards: 1
+  index.number_of_replicas: 0
   index.codec: best_compression
 
 

--- a/templates/metricbeat/metricbeat.yml.j2
+++ b/templates/metricbeat/metricbeat.yml.j2
@@ -1,5 +1,7 @@
 ###################### Metricbeat Configuration
 #
+# {{ ansible_managed }}
+#
 # You can find the full configuration reference here:
 # https://www.elastic.co/guide/en/beats/metricbeat/index.html
 
@@ -14,6 +16,7 @@ metricbeat.config.modules:
 
 setup.template.settings:
   index.number_of_shards: 1
+  index.number_of_replicas: 0
   index.codec: best_compression
   #_source.enabled: false
 

--- a/templates/metricbeat/module_apache.yml.j2
+++ b/templates/metricbeat/module_apache.yml.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+#
 # Module: apache
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-apache.html
 

--- a/templates/metricbeat/module_kibana.yml.j2
+++ b/templates/metricbeat/module_kibana.yml.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+#
 # Module: kibana
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-kibana.html
 

--- a/templates/metricbeat/module_mysql.yml.j2
+++ b/templates/metricbeat/module_mysql.yml.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+#
 # Module: mysql
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-mysql.html
 

--- a/templates/metricbeat/module_system.yml.j2
+++ b/templates/metricbeat/module_system.yml.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+#
 # Module: system
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-system.html
 


### PR DESCRIPTION
path Elastic Beats confi files to force ES index replicas to 0 as RGM internal ES cluster is composed of only one node