### PR TITLE
Fix Linux Onliner password usage

### DIFF
--- a/templates/distrib/markdown/linux_metricbeat_instructions.md
+++ b/templates/distrib/markdown/linux_metricbeat_instructions.md
@@ -5,5 +5,5 @@ Log in as *root* user either by _SSH_ or on local _console_
 ## Execute the one-liner
 
 ```
-bash <(curl -k -s https://{{ ansible_default_ipv4.address }}/distrib/install/install-metricbeat.bash) -u admin -p ********
+bash <(curl -k -s https://{{ ansible_default_ipv4.address }}/distrib/install/install-metricbeat.bash) -u <RGMAPI username> -p <RGMAPI password>
 ```

--- a/templates/distrib/markdown/linux_metricbeat_instructions.md
+++ b/templates/distrib/markdown/linux_metricbeat_instructions.md
@@ -5,5 +5,5 @@ Log in as *root* user either by _SSH_ or on local _console_
 ## Execute the one-liner
 
 ```
-bash <(curl -k -s https://{{ ansible_default_ipv4.address }}/distrib/install/install-metricbeat.bash)
+bash <(curl -k -s https://{{ ansible_default_ipv4.address }}/distrib/install/install-metricbeat.bash) -u admin -p ********
 ```

--- a/templates/distrib/payload/Add-RGMHost.ps1
+++ b/templates/distrib/payload/Add-RGMHost.ps1
@@ -67,7 +67,7 @@ function Test-RGMApiToken {
 
     $UriTokenCheck = "https://$RGMServer/rgmapi/checkAuthToken"
     try {
-        $null = Invoke-RestMethod -Uri $UriTokenCheck -Method GET -Headers $:scriptHeader
+        $null = Invoke-RestMethod -Uri $UriTokenCheck -Method GET -Headers $script:Header
     }
     catch {
         Write-Verbose "Token non valide"

--- a/templates/distrib/payload/install-metricbeat.bash
+++ b/templates/distrib/payload/install-metricbeat.bash
@@ -4,7 +4,7 @@
 #
 # RGM deployment script for Linux MetricBeat
 
-RGMSRVR="172.16.81.25"
+RGMSRVR="{{ ansible_default_ipv4.address }}"
 RGM_HOST_TMPL='RGM_LINUX_ES'
 RGM_HOST_ALIAS="$(hostname -s)"
 EXPORTCONFIG=1
@@ -76,8 +76,10 @@ if [ -n "$RGMAPI_OTT" ]; then
     RCHTTP=$?
 fi
 if [ "$RCHTTP" != '200' ] && [ -n "$RGMAPI_USER" ] && [ -n "$RGMAPI_PASSWD" ]; then
-    RGMAPI_OTT="$(curl -s -k -H 'Content-Type: application/json' \
-        "https://${RGMSRVR}/rgmapi/getAuthToken?&username=${RGMAPI_USER}&password=${RGMAPI_PASSWD}" |
+    RGMAPI_OTT="$(curl -s -k -G -H 'Content-Type: application/json' \
+        --data-urlencode "username=${RGMAPI_USER}" \
+        --data-urlencode "password=${RGMAPI_PASSWD}" \
+        "https://${RGMSRVR}/rgmapi/getAuthToken" |
         grep RGMAPI_TOKEN | awk '{print $2}' | xargs)"
     api_check_auth "$RGMAPI_OTT"
     RCHTTP=$?


### PR DESCRIPTION
When the password content special characters, the request token method failed!

Now the password is well transmeted and the token is delivered enven with complex password

 - fix a typo on check token validity on the powershell script without impact until a One time Token not used
 - fix ip in the code. replaced with good jinja code

